### PR TITLE
CD-43: Un-ignore primary Sass file

### DIFF
--- a/html/.gitignore
+++ b/html/.gitignore
@@ -8,4 +8,4 @@ sites/*/private
 **/node_modules/
 **/.sass-cache/
 **/.DS_Store
-sites/all/themes/custom/ocha-basic/assets/css/
+sites/all/themes/custom/ocha-basic/assets/css/*.css

--- a/html/sites/all/themes/custom/ocha-basic/Gruntfile.js
+++ b/html/sites/all/themes/custom/ocha-basic/Gruntfile.js
@@ -6,13 +6,13 @@ module.exports = function(grunt) {
     sass: {
       dist: {
         files: {
-          'assets/css/styles.css': 'assets/css/styles.scss'
+          'assets/css/styles.css': 'assets/sass/styles.scss'
         }
       }
     },
     watch: {
       sass: {
-        files: ['assets/css/styles.scss', 'assets/sass/**/*.scss'],
+        files: ['assets/sass/styles.scss', 'assets/sass/**/*.scss'],
         tasks: ['sass', 'autoprefixer'],
         options: {
           spawn: false,

--- a/html/sites/all/themes/custom/ocha-basic/assets/css/styles.scss
+++ b/html/sites/all/themes/custom/ocha-basic/assets/css/styles.scss
@@ -1,0 +1,62 @@
+//——————————————————————————————————————————————————————————————————————————————
+// Common Design: Global
+//——————————————————————————————————————————————————————————————————————————————
+@import '../sass/cd/cd-variables';
+@import '../sass/cd/cd-extends';
+@import '../sass/cd/cd-mixins';
+@import '../sass/cd/cd-reset';
+
+
+//——————————————————————————————————————————————————————————————————————————————
+// Events: global / resets
+//——————————————————————————————————————————————————————————————————————————————
+@import '../sass/base/_a-reset';
+@import '../sass/base/_base';
+@import '../sass/base/_grid';
+@import '../sass/base/_helpers';
+@import '../sass/base/_typography';
+
+// Instead of CD icons, Events includes extra icons not in the CD set. It also
+// lacks the social media icons so using their set makes much more sense.
+@import '../sass/components/_icons';
+
+
+//——————————————————————————————————————————————————————————————————————————————
+// Common Design: Header/Footer components
+//——————————————————————————————————————————————————————————————————————————————
+
+// Layout
+@import '../sass/cd-layout/cd-layout';
+
+// Header
+@import '../sass/cd-header/cd-header';
+@import '../sass/cd-header/cd-dropdowns';
+@import '../sass/cd-header/cd-logo';
+@import '../sass/cd-header/cd-nav';
+@import '../sass/cd-header/cd-search';
+@import '../sass/cd-header/cd-sites-menu';
+@import '../sass/cd-header/cd-sites-menu--compact';
+@import '../sass/cd-header/cd-user-menu';
+
+// Footer
+@import '../sass/cd-footer/cd-footer';
+@import '../sass/cd-footer/cd-footer-copyright';
+@import '../sass/cd-footer/cd-footer-menu';
+@import '../sass/cd-footer/cd-footer-social';
+@import '../sass/cd-footer/cd-mandate';
+@import '../sass/cd-footer/cd-soft-footer';
+
+
+//——————————————————————————————————————————————————————————————————————————————
+// Events: components
+//——————————————————————————————————————————————————————————————————————————————
+@import '../sass/components/_buttons';
+@import '../sass/components/_calendar-actions';
+@import '../sass/components/_chosen';
+@import '../sass/components/_dropdown';
+@import '../sass/components/_event';
+@import '../sass/components/_forms';
+@import '../sass/components/_fullcalendar';
+@import '../sass/components/_main-content';
+@import '../sass/components/_sidebar';
+@import '../sass/components/_tabs';

--- a/html/sites/all/themes/custom/ocha-basic/assets/sass/styles.scss
+++ b/html/sites/all/themes/custom/ocha-basic/assets/sass/styles.scss
@@ -1,24 +1,24 @@
 //——————————————————————————————————————————————————————————————————————————————
 // Common Design: Global
 //——————————————————————————————————————————————————————————————————————————————
-@import '../sass/cd/cd-variables';
-@import '../sass/cd/cd-extends';
-@import '../sass/cd/cd-mixins';
-@import '../sass/cd/cd-reset';
+@import 'cd/cd-variables';
+@import 'cd/cd-extends';
+@import 'cd/cd-mixins';
+@import 'cd/cd-reset';
 
 
 //——————————————————————————————————————————————————————————————————————————————
 // Events: global / resets
 //——————————————————————————————————————————————————————————————————————————————
-@import '../sass/base/_a-reset';
-@import '../sass/base/_base';
-@import '../sass/base/_grid';
-@import '../sass/base/_helpers';
-@import '../sass/base/_typography';
+@import 'base/_a-reset';
+@import 'base/_base';
+@import 'base/_grid';
+@import 'base/_helpers';
+@import 'base/_typography';
 
 // Instead of CD icons, Events includes extra icons not in the CD set. It also
 // lacks the social media icons so using their set makes much more sense.
-@import '../sass/components/_icons';
+@import 'components/_icons';
 
 
 //——————————————————————————————————————————————————————————————————————————————
@@ -26,37 +26,37 @@
 //——————————————————————————————————————————————————————————————————————————————
 
 // Layout
-@import '../sass/cd-layout/cd-layout';
+@import 'cd-layout/cd-layout';
 
 // Header
-@import '../sass/cd-header/cd-header';
-@import '../sass/cd-header/cd-dropdowns';
-@import '../sass/cd-header/cd-logo';
-@import '../sass/cd-header/cd-nav';
-@import '../sass/cd-header/cd-search';
-@import '../sass/cd-header/cd-sites-menu';
-@import '../sass/cd-header/cd-sites-menu--compact';
-@import '../sass/cd-header/cd-user-menu';
+@import 'cd-header/cd-header';
+@import 'cd-header/cd-dropdowns';
+@import 'cd-header/cd-logo';
+@import 'cd-header/cd-nav';
+@import 'cd-header/cd-search';
+@import 'cd-header/cd-sites-menu';
+@import 'cd-header/cd-sites-menu--compact';
+@import 'cd-header/cd-user-menu';
 
 // Footer
-@import '../sass/cd-footer/cd-footer';
-@import '../sass/cd-footer/cd-footer-copyright';
-@import '../sass/cd-footer/cd-footer-menu';
-@import '../sass/cd-footer/cd-footer-social';
-@import '../sass/cd-footer/cd-mandate';
-@import '../sass/cd-footer/cd-soft-footer';
+@import 'cd-footer/cd-footer';
+@import 'cd-footer/cd-footer-copyright';
+@import 'cd-footer/cd-footer-menu';
+@import 'cd-footer/cd-footer-social';
+@import 'cd-footer/cd-mandate';
+@import 'cd-footer/cd-soft-footer';
 
 
 //——————————————————————————————————————————————————————————————————————————————
 // Events: components
 //——————————————————————————————————————————————————————————————————————————————
-@import '../sass/components/_buttons';
-@import '../sass/components/_calendar-actions';
-@import '../sass/components/_chosen';
-@import '../sass/components/_dropdown';
-@import '../sass/components/_event';
-@import '../sass/components/_forms';
-@import '../sass/components/_fullcalendar';
-@import '../sass/components/_main-content';
-@import '../sass/components/_sidebar';
-@import '../sass/components/_tabs';
+@import 'components/_buttons';
+@import 'components/_calendar-actions';
+@import 'components/_chosen';
+@import 'components/_dropdown';
+@import 'components/_event';
+@import 'components/_forms';
+@import 'components/_fullcalendar';
+@import 'components/_main-content';
+@import 'components/_sidebar';
+@import 'components/_tabs';


### PR DESCRIPTION
Follow-up to #341 — previous config of the repo was ignoring changes to a key file that I've unignored in this PR, which should allow Grunt to generate CSS.

I think a longer-term solution is to avoid storing Sass files in the `css` dir and store them in `sass` where they belong. But my fix here will keep most things untouched while restoring the missing Sass file.